### PR TITLE
Fix brew checks in completion scripts

### DIFF
--- a/49_bash_completion.sh
+++ b/49_bash_completion.sh
@@ -2,6 +2,6 @@ if [ -f /opt/local/etc/bash_completion ]; then
     . /opt/local/etc/bash_completion
 fi
 
-if [ -f $(brew --prefix)/etc/bash_completion ]; then
-    . $(brew --prefix)/etc/bash_completion
+if command -v brew >/dev/null && [ -f "$(brew --prefix)/etc/bash_completion" ]; then
+    . "$(brew --prefix)/etc/bash_completion"
 fi

--- a/49_zsh-completions.zsh
+++ b/49_zsh-completions.zsh
@@ -1,4 +1,4 @@
-if type brew &>/dev/null && [ -d $(brew --prefix)/share/zsh-completions ]; then
+if command -v brew >/dev/null && [ -d "$(brew --prefix)/share/zsh-completions" ]; then
     fpath=($(brew --prefix)/share/zsh-completions $fpath)
 
     autoload -Uz compinit


### PR DESCRIPTION
## Summary
- ensure `brew` exists before referencing `brew --prefix` in bash/zsh completion scripts

## Testing
- `bun test` *(fails: no tests found)*
- `bun mutate` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec4b5960832f96939e5f2c730702