### PR TITLE
Fix 1Password plugin sourcing path

### DIFF
--- a/99_1password-plugins.sh
+++ b/99_1password-plugins.sh
@@ -1,1 +1,1 @@
-source /Users/craig/.config/op/plugins.sh
+source "$HOME/.config/op/plugins.sh"


### PR DESCRIPTION
## Summary
- update `99_1password-plugins.sh` so the plugin path uses `$HOME`
- keep the zsh version synced via its symlink

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6842ec35e150832fab20936dd035f1ce