### PR TITLE
Fix brew prefix quoting

### DIFF
--- a/49_zsh-completions.zsh
+++ b/49_zsh-completions.zsh
@@ -1,5 +1,5 @@
 if command -v brew >/dev/null && [ -d "$(brew --prefix)/share/zsh-completions" ]; then
-    fpath=($(brew --prefix)/share/zsh-completions $fpath)
+    fpath=("$(brew --prefix)/share/zsh-completions" $fpath)
 
     autoload -Uz compinit
     compinit

--- a/ruby-build-with-brew-openssl.sh
+++ b/ruby-build-with-brew-openssl.sh
@@ -1,1 +1,1 @@
-export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=\"$(brew --prefix openssl@1.1)\""


### PR DESCRIPTION
## Summary
- quote `$(brew --prefix)` usage inside zsh completion initialization
- ensure ruby-build uses quoted brew prefix path

## Testing
- `bun test`
- `bun mutate` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed8af82c832fb03ef2e951e4cb6f